### PR TITLE
Extend 32X support

### DIFF
--- a/src/main/java/sega/MarsUserHeader.java
+++ b/src/main/java/sega/MarsUserHeader.java
@@ -1,0 +1,93 @@
+package sega;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.Structure;
+import ghidra.program.model.data.StructureDataType;
+
+class MarsUserHeader implements StructConverter {
+	private byte[] moduleName = null;
+	private long version = 0;
+	private long sourceAddress = 0;
+	private long destinationAddress = 0;
+	private long size = 0;
+	private long sh2MasterStartAddress = 0;
+	private long sh2SlaveStartAddress = 0;
+	private long sh2MasterVectorBaseAddress = 0;
+	private long sh2SlaveVectorBaseAddress = 0;
+
+	MarsUserHeader(BinaryReader reader) throws IOException {
+
+		if (reader.length() < 0x2d) {
+			return;
+		}
+
+		reader.setPointerIndex(0x3c0);
+
+		moduleName = reader.readNextByteArray(0x10);
+		version = reader.readNextUnsignedInt();
+		sourceAddress = reader.readNextUnsignedInt();
+		destinationAddress = reader.readNextUnsignedInt();
+		size = reader.readNextUnsignedInt();
+		sh2MasterStartAddress = reader.readNextUnsignedInt();
+		sh2SlaveStartAddress = reader.readNextUnsignedInt();
+		sh2MasterVectorBaseAddress = reader.readNextUnsignedInt();
+		sh2SlaveVectorBaseAddress = reader.readNextUnsignedInt();
+	}
+
+	@Override
+	public DataType toDataType() {
+		Structure s = new StructureDataType("MARSUserHeader", 0);
+
+		s.add(STRING, 0x10, "moduleName", null);
+		s.add(DWORD, 0x04, "version", null);
+		s.add(POINTER, 0x04, "sourceAddress", null);
+		s.add(POINTER, 0x04, "destinationAddress", null);
+		s.add(DWORD, 0x04, "size", null);
+		s.add(POINTER, 0x04, "sh2MasterStartAddress", null);
+		s.add(POINTER, 0x04, "sh2SlaveStartAddress", null);
+		s.add(POINTER, 0x04, "sh2MasterVectorBaseAddress", null);
+		s.add(POINTER, 0x04, "sh2SlaveVectorBaseAddress", null);
+
+		return s;
+	}
+
+	public byte[] getModuleName() {
+		return moduleName;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public long getSourceAddress() {
+		return sourceAddress;
+	}
+
+	public long getDestinationAddress() {
+		return destinationAddress;
+	}
+
+	public long getSize() {
+		return size;
+	}
+
+	public long getSh2MasterStartAddress() {
+		return sh2MasterStartAddress;
+	}
+
+	public long getSh2SlaveStartAddress() {
+		return sh2SlaveStartAddress;
+	}
+
+	public long getSh2MasterVectorBaseAddress() {
+		return sh2MasterVectorBaseAddress;
+	}
+
+	public long getSh2SlaveVectorBaseAddress() {
+		return sh2SlaveVectorBaseAddress;
+	}
+}

--- a/src/main/java/sega/SegaLoader.java
+++ b/src/main/java/sega/SegaLoader.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import docking.widgets.OptionDialog;
 import ghidra.app.cmd.data.CreateArrayCmd;
+import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
@@ -29,9 +30,11 @@ import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
 import ghidra.framework.store.LockException;
+import ghidra.program.disassemble.Disassembler;
 import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressOverflowException;
+import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.data.ByteDataType;
 import ghidra.program.model.data.DWordDataType;
 import ghidra.program.model.data.DataType;
@@ -39,12 +42,14 @@ import ghidra.program.model.data.DataUtilities;
 import ghidra.program.model.data.DataUtilities.ClearDataMode;
 import ghidra.program.model.data.WordDataType;
 import ghidra.program.model.lang.LanguageCompilerSpecPair;
+import ghidra.program.model.listing.BookmarkType;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.mem.MemoryConflictException;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
 
@@ -54,9 +59,11 @@ import ghidra.util.task.TaskMonitor;
 public class SegaLoader extends AbstractLibrarySupportLoader {
 
 	public static final String LOADER_NAME = "Sega Mega Drive / Genesis Loader";
-	
+
 	private VectorsTable vectors;
 	private GameHeader header;
+	private MarsUserHeader marsUserHeader;
+	private SegmentOptions segmentOptions;
 
 	@Override
 	public String getName() {
@@ -71,6 +78,10 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 
 		if (reader.readAsciiString(0x100, 4).equals("SEGA")) {
 			loadSpecs.add(new LoadSpec(this, 0, new LanguageCompilerSpecPair("68000:BE:32:MC68020", "default"), true));
+
+			if (reader.readAsciiString(0x3c0, 15).equals("MARS CHECK MODE")) {
+				loadSpecs.add(new LoadSpec(this, 0, new LanguageCompilerSpecPair("SuperH:BE:32:SH-2", "default"), false));
+			}
 		}
 
 		return loadSpecs;
@@ -84,30 +95,36 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 		BinaryReader reader = new BinaryReader(provider, false);
 		FlatProgramAPI fpa = new FlatProgramAPI(program, monitor);
 
-		vectors = new VectorsTable(fpa, reader);
-		header = new GameHeader(reader);
+		segmentOptions = new SegmentOptions(loadSpec, log);
+		if (!segmentOptions.hasSH2MemoryMap) {
+			vectors = new VectorsTable(fpa, reader);
+			header = new GameHeader(reader);
+		}
+		if (segmentOptions.has32XSegments) {
+			marsUserHeader = new MarsUserHeader(reader);
+		}
 
-		createSegments(fpa, provider, program, log);
-		markVectorsTable(program, fpa, log);
-		markHeader(program, fpa, log);
+		createSegments(fpa, provider, loadSpec, program, monitor, log);
+		if (!segmentOptions.hasSH2MemoryMap) {
+			markVectorsTable(program, fpa, log);
+			markHeader(program, fpa, log);
+		}
+		if (segmentOptions.has32XSegments) {
+			markMarsUserHeader(program, fpa, log);
+		}
 
 		monitor.setMessage(String.format("%s : Loading done", getName()));
 	}
 
-	private void createSegments(FlatProgramAPI fpa, ByteProvider provider, Program program,
-								MessageLog log) throws IOException {
+	private void createSegments(FlatProgramAPI fpa, ByteProvider provider, LoadSpec loadSpec, Program program, TaskMonitor monitor, MessageLog log) throws IOException {
 		InputStream romStream = provider.getInputStream(0);
 
-		createSegment(fpa, romStream, "ROM", 0x000000L, Math.min(romStream.available(), 0x3FFFFFL), true, false, true, false,
-				log);
-
-		try {
-			TimeUnit.SECONDS.sleep(1);
-		} catch (InterruptedException e) {
+		if (!segmentOptions.hasSH2MemoryMap) {
+			createSegment(fpa, romStream, "ROM", 0x000000L, Math.min(romStream.available(), 0x3FFFFFL), true, false, true, false,
+					log);
 		}
-		
-		if (OptionDialog.YES_OPTION == OptionDialog.showYesNoDialogWithNoAsDefaultButton(null, "Question",
-				"Create Sega CD segment?")) {
+
+		if (segmentOptions.hasSegaCDSegments) {
 			if (romStream.available() > 0x3FFFFFL) {
 				createSegment(fpa, provider.getInputStream(0x400000L), "EPA", 0x400000L, 0x400000L, true, true, false, false,
 						log);
@@ -116,9 +133,117 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 			}
 		}
 
-		if (OptionDialog.YES_OPTION == OptionDialog.showYesNoDialogWithNoAsDefaultButton(null, "Question",
-				"Create Sega 32X segment?")) {
-			createSegment(fpa, null, "32X", 0x800000L, 0x200000L, true, true, false, false, log);
+		if (segmentOptions.has32XSegments) {
+			createSegment(fpa, null, "32X_PRIV", 0x800000L, 0x40000L, true, true, false, false, log);
+			createSegment(fpa, null, "32X_DRAM", 0x840000L, 0x20000L, true, true, false, false, log);
+			createSegment(fpa, null, "32X_OWIMG", 0x860000L, 0x20000L, true, true, false, false, log);
+
+			createSegment(fpa, provider.getInputStream(0), "32X_ROM_FIXED", 0x880000L, 0x80000L, true, true, true, false, log);
+			long bank_size = 0x100000L;
+			long bank_offset = 0x900000L;
+			for (int i = 0; i < 4; i++) {
+				createSegment(fpa, provider.getInputStream(Math.min(romStream.available(), bank_size * i)),
+						"32X_ROM_BANK" + i, bank_offset, bank_size, true, true, true, false, true, log);
+				if (romStream.available() < bank_size * (i + 1)) {
+					break;
+				}
+			}
+
+			createSegment(fpa, null, "32X_ID", 0xA130ECL, 0x4L, true, true, false, false, log);
+			createNamedData(fpa, program, 0xA130ECL, "IO_32X_ID", DWordDataType.dataType, log);
+
+			createSegment(fpa, null, "32X_BANK_SET_REG", 0xA130F1L, 0xFL, true, true, false, false, log);
+			createNamedArray(fpa, program, 0xA130F1L, "IO_32X_BANK_SET_REG", 0xF, WordDataType.dataType, log);
+
+			createSegment(fpa, null, "32X_SYS_REG", 0xA15100L, 0x80L, true, true, false, false, log);
+			createNamedData(fpa, program, 0xA15100L, "IO_32X_VDP_CTRL", ByteDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15101L, "IO_32X_ADAPTER_CTRL", ByteDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15102L, "IO_32X_SH2_INT_CTRL", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15104L, "IO_32X_BANK_CTRL", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15106L, "IO_32X_DREQ_CTRL", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15108L, "IO_32X_68K_SH2_DREQ_SRC", DWordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA1510cL, "IO_32X_68K_SH2_DREQ_DEST", DWordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15110L, "IO_32X_68K_SH2_DREQ_LEN", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15112L, "IO_32X_68K_SH2_DREQ_FIFO", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA1511bL, "IO_32X_SEGA_TV_REG", ByteDataType.dataType, log);
+			createNamedArray(fpa, program, 0xA15120L, "IO_32X_COMM", 0x10, ByteDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15130L, "IO_32X_PWM_CTRL", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15132L, "IO_32X_CYCLE_REG", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15134L, "IO_32X_L_CH_PULSE_REG", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15136L, "IO_32X_R_CH_PULSE_REG", WordDataType.dataType, log);
+			createNamedData(fpa, program, 0xA15138L, "IO_32X_MONO_PULSE_REG", WordDataType.dataType, log);
+
+			createSegment(fpa, null, "32X_VDP_REG", 0xA15180L, 0x80L, true, true, false, false, log);
+			createNamedArray(fpa, program, 0xA15180L, "IO_32X_VDP_REG", 0x80, ByteDataType.dataType, log);
+
+			createSegment(fpa, null, "32X_PAL", 0xA15200L, 0x200L, true, true, false, false, log);
+			createNamedArray(fpa, program, 0xA15200L, "IO_32X_PAL", 0x100, WordDataType.dataType, log);
+
+			if (segmentOptions.hasSH2MemoryMap) {
+				// SH-2 Cache
+				createSegment(fpa, null, "SH2_BOOT_ROM", 0x00000000L, 0x4000L, true, false, true, false, log);
+
+				createSegment(fpa, null, "SH2_SYS_REG", 0x00004000L, 0x100L, true, true, false, false, log);
+				createNamedData(fpa, program, 0x00004000L, "IO_SH2_ADAPTER_CTRL", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004001L, "IO_SH2_INT_CTRL", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004002L, "IO_SH2_STANDBY", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004005L, "IO_SH2_H_COUNT_REG", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004006L, "IO_SH2_DREQ_CTRL", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004008L, "IO_SH2_DREQ_SRC", DWordDataType.dataType, log);
+				createNamedData(fpa, program, 0x0000400cL, "IO_SH2_DREQ_DEST", DWordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004010L, "IO_SH2_DREQ_LEN", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004012L, "IO_SH2_DREQ_FIFO", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004014L, "IO_SH2_VRES_INT_CLEAR", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004016L, "IO_SH2_V_INT_CLEAR", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004018L, "IO_SH2_H_INT_CLEAR", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x0000401aL, "IO_SH2_CMD_INT_CLEAR", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x0000401cL, "IO_SH2_PWM_INT_CLEAR", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x0000401eL, "IO_SH2_UNUSED", WordDataType.dataType, log);
+				createNamedArray(fpa, program, 0x00004020L, "IO_SH2_COMM", 0x10, ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004030L, "IO_32X_TIMER_CTRL", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004031L, "IO_32X_PWM_CTRL", ByteDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004032L, "IO_32X_CYCLE_REG", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004034L, "IO_32X_L_CH_PULSE_REG", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004036L, "IO_32X_R_CH_PULSE_REG", WordDataType.dataType, log);
+				createNamedData(fpa, program, 0x00004038L, "IO_32X_MONO_PULSE_REG", WordDataType.dataType, log);
+
+				createSegment(fpa, null, "SH2_VDP_REG", 0x00004100L, 0x100L, true, true, false, false, log);
+				createSegment(fpa, null, "SH2_PAL", 0x00004200L, 0x200L, true, true, false, false, log);
+				createSegment(fpa, provider.getInputStream(0), "SH2_ROM", 0x02000000L, 0x400000L, true, false, true, false, log);
+				createSegment(fpa, null, "SH2_DRAM", 0x04000000L, 0x20000L, true, true, false, false, log);
+				createSegment(fpa, null, "SH2_OWIMG", 0x04020000L, 0x20000L, true, true, false, false, log);
+				createSegment(fpa, provider.getInputStream(marsUserHeader.getSourceAddress()), "SH2_SDRAM", 0x06000000L, 0x40000L, true, true, true, false, log);
+
+				// SH-2 Cache through
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_BOOT_ROM", 0x00000000L, 0x20000000L, 0x4000L, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_SYS_REG", 0x00004000L, 0x20004000L, 0x100L, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_VDP_REG", 0x00004100L, 0x20004100L, 0x100L, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_PAL", 0x00004200L, 0x20004200L, 0x200L, log);
+				createSegment(fpa, provider.getInputStream(0), "SH2_CT_ROM", 0x22000000L, 0x400000L, true, false, true, false, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_DRAM", 0x04000000L, 0x24000000L, 0x20000L, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_OWIMG", 0x04020000L, 0x24020000L, 0x20000L, log);
+				createMirrorSegment(program.getMemory(), fpa, "SH2_CT_SDRAM", 0x06000000L, 0x26000000L, 0x40000L, log);
+
+				createFunction(fpa, program, monitor, marsUserHeader.getSh2MasterStartAddress(), "SHM_entry");
+				createFunction(fpa, program, monitor, marsUserHeader.getSh2SlaveStartAddress(), "SHS_entry");
+			} else {
+				// Jump table after Game Header
+				AddressSet set = new AddressSet(fpa.toAddr(0x200), fpa.toAddr(0x3c0));
+				Disassembler dis = Disassembler.getDisassembler(program, monitor, null);
+				while (!set.isEmpty()) {
+					AddressSet disassembleAddrs = dis.disassemble(set.getMinAddress(), set, true);
+					if (disassembleAddrs.isEmpty()) {
+						try {
+							program.getBookmarkManager().removeBookmarks(set, BookmarkType.ERROR, Disassembler.ERROR_BOOKMARK_CATEGORY, monitor);
+						} catch (CancelledException e) {
+							log.appendException(e);
+						}
+						break;
+					}
+					AutoAnalysisManager.getAnalysisManager(program).codeDefined(disassembleAddrs);
+					set.delete(disassembleAddrs);
+				}
+			}
 		}
 
 		createSegment(fpa, null, "Z80", 0xA00000L, 0x10000L, true, true, false, false, log);
@@ -154,8 +279,10 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 		createSegment(fpa, null, "FDC", 0xA12000L, 0x100, true, true, false, true, log);
 		createNamedArray(fpa, program, 0xA12000L, "IO_FDC", 0x100, ByteDataType.dataType, log);
 
-		createSegment(fpa, null, "TIME", 0xA13000L, 0x100, true, true, false, true, log);
-		createNamedArray(fpa, program, 0xA13000L, "IO_TIME", 0x100, ByteDataType.dataType, log);
+		// Leave last bytes for 32X bank register and 32X ID
+		int timeSegmentSize = segmentOptions.has32XSegments ? 0xEC : 0x100;
+		createSegment(fpa, null, "TIME", 0xA13000L, timeSegmentSize, true, true, false, true, log);
+		createNamedArray(fpa, program, 0xA13000L, "IO_TIME", timeSegmentSize, ByteDataType.dataType, log);
 
 		createSegment(fpa, null, "TMSS", 0xA14000L, 4, true, true, false, true, log);
 		createNamedData(fpa, program, 0xA14000L, "IO_TMSS", DWordDataType.dataType, log);
@@ -173,6 +300,14 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 
 		createSegment(fpa, null, "RAM", 0xFF0000L, 0x10000L, true, true, true, false, log);
 		createMirrorSegment(program.getMemory(), fpa, "RAM", 0xFF0000L, 0xFFFF0000L, 0x10000L, log);
+	}
+
+	private void createFunction(FlatProgramAPI fpa, Program program, TaskMonitor monitor, long offset, String name) {
+		Address address = fpa.toAddr(offset);
+		fpa.createFunction(address, name);
+		Disassembler dis = Disassembler.getDisassembler(program, monitor, null);
+		AddressSet disassembleAddrs = dis.disassemble(address, null);
+		AutoAnalysisManager.getAnalysisManager(program).codeDefined(disassembleAddrs);
 	}
 
 	private void markVectorsTable(Program program, FlatProgramAPI fpa, MessageLog log) {
@@ -196,7 +331,16 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 			log.appendException(e);
 		}
 	}
-	
+
+	private void markMarsUserHeader(Program program, FlatProgramAPI fpa, MessageLog log) {
+		try {
+			DataUtilities.createData(program, fpa.toAddr(0x3c0 + (segmentOptions.hasSH2MemoryMap ? 0x880000 : 0)), marsUserHeader.toDataType(), -1, false,
+					ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
+		} catch (CodeUnitInsertionException e) {
+			log.appendException(e);
+		}
+	}
+
 	private void createNamedArray(FlatProgramAPI fpa, Program program, long address, String name, int numElements, DataType type, MessageLog log) {
 		try {
 			CreateArrayCmd arrayCmd = new CreateArrayCmd(fpa.toAddr(address), numElements, type, type.getLength());
@@ -224,9 +368,14 @@ public class SegaLoader extends AbstractLibrarySupportLoader {
 
 	private void createSegment(FlatProgramAPI fpa, InputStream stream, String name, long address, long size,
 			boolean read, boolean write, boolean execute, boolean volatil, MessageLog log) {
+	    createSegment(fpa, stream, name, address, size, read, write, execute, volatil, false, log);
+    }
+
+	private void createSegment(FlatProgramAPI fpa, InputStream stream, String name, long address, long size,
+			boolean read, boolean write, boolean execute, boolean volatil, boolean overlay, MessageLog log) {
 		MemoryBlock block;
 		try {
-			block = fpa.createMemoryBlock(name, fpa.toAddr(address), stream, size, false);
+			block = fpa.createMemoryBlock(name, fpa.toAddr(address), stream, size, overlay);
 			block.setRead(read);
 			block.setWrite(write);
 			block.setExecute(execute);

--- a/src/main/java/sega/SegmentOptions.java
+++ b/src/main/java/sega/SegmentOptions.java
@@ -1,0 +1,34 @@
+package sega;
+
+import java.util.concurrent.TimeUnit;
+
+import docking.widgets.OptionDialog;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.LoadSpec;
+import ghidra.program.model.lang.LanguageNotFoundException;
+
+public class SegmentOptions {
+	public final boolean hasSH2MemoryMap;
+	public final boolean has32XSegments;
+	public final boolean hasSegaCDSegments;
+
+	public SegmentOptions(LoadSpec loadSpec, MessageLog log) throws LanguageNotFoundException {
+		String languageID = loadSpec.getLanguageCompilerSpec().getLanguage().getLanguageID().getIdAsString();
+		this.hasSH2MemoryMap = languageID.contains("SuperH");
+		log.appendMsg(String.format("LanguageID is %s, adding Mega Drive segments assuming 32X is %s",
+				languageID,
+				this.hasSH2MemoryMap ? "loaded" : "NOT loaded"));
+
+		try {
+			TimeUnit.SECONDS.sleep(1);
+		} catch (InterruptedException e) {
+			log.appendException(e);
+		}
+
+		this.has32XSegments = OptionDialog.YES_OPTION == OptionDialog.showYesNoDialogWithNoAsDefaultButton(null, "Question",
+				"Create Sega 32X segments?");
+
+		this.hasSegaCDSegments = OptionDialog.YES_OPTION == OptionDialog.showYesNoDialogWithNoAsDefaultButton(null, "Question",
+				"Create Sega CD segment?");
+	}
+}


### PR DESCRIPTION
Adds several segments, registers, and a header respective to the 32X.

In case a 32X signature is detected, it also gives users the option to select SH-2 as a language, to allow disassembling SH-2 code.

Since there are some incompatibilities between the Mega Drive memory map and SH-2 memory map, I decided to separate these by looking at the chosen language and creating some segments accordingly.

If you are curious, you can check this write-up for a game where I applied these changes: https://qufb.gitlab.io/writeups/2022/10/19/3-CPUs-1-Cheat